### PR TITLE
[VaVirtualScroller]: Fix wrong generated filename on package

### DIFF
--- a/packages/ui/src/components/va-virtual-scroller/VaVirtualScroller.vue
+++ b/packages/ui/src/components/va-virtual-scroller/VaVirtualScroller.vue
@@ -31,7 +31,7 @@
   </div>
 </template>
 
-<script lang="ts" setup generic="Item = unknown">
+<script lang="ts" setup generic="Item">
 import { ref, computed, watch, PropType } from 'vue'
 import pick from 'lodash/pick.js'
 


### PR DESCRIPTION
## Description
Removing the generic default should generate a filename without URL encoded values in the package. As it the generic default is unnecessary for its use anyway. This does not solve the core naming issue (as probably the generic should not be part of the name in any scenario when packing) this should solve the specific issue mentioned here:
https://github.com/epicmaxco/vuestic-ui/issues/4156

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
